### PR TITLE
Make ELO Roles Feature Optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ DISCORD_GUILD_ID=your_guild_id_here
 # Wordle Bot User ID
 WORDLE_BOT_ID=1211781489931452447
 
-# Role IDs for ELO ranking
+# Role IDs for ELO ranking (optional, disabled if not defined)
 HIGHEST_ELO_ROLE_ID=your_highest_elo_role_id_here
 LOWEST_ELO_ROLE_ID=your_lowest_elo_role_id_here
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ An ELO-based ranking system for Discord's Wordle bot. Track player performance, 
    DISCORD_BOT_TOKEN=your_bot_token
    DISCORD_CLIENT_ID=your_client_id
    DISCORD_GUILD_ID=your_guild_id  # Optional, for faster command registration
-   HIGHEST_ELO_ROLE_ID=your_role_id
-   LOWEST_ELO_ROLE_ID=your_role_id
+   HIGHEST_ELO_ROLE_ID=your_role_id # Optional, disabled if not defined
+   LOWEST_ELO_ROLE_ID=your_role_id # Optional, disabled if not defined
    ```
 
 5. Deploy slash commands:
@@ -79,7 +79,7 @@ An ELO-based ranking system for Discord's Wordle bot. Track player performance, 
    - Select permissions: `Manage Roles`, `Send Messages`, `Read Message History`, `Use Slash Commands`
 7. Use the generated URL to invite the bot to your server
 
-## Creating Roles
+## Creating Roles (Optional)
 
 Create two roles in your Discord server:
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -55,8 +55,8 @@ export function loadConfig(): BotConfig {
         'WORDLE_BOT_ID',
         '1211781489931452447'
       ) as Snowflake,
-      highestEloRoleId: getRequiredEnv('HIGHEST_ELO_ROLE_ID') as Snowflake,
-      lowestEloRoleId: getRequiredEnv('LOWEST_ELO_ROLE_ID') as Snowflake
+      highestEloRoleId: process.env.HIGHEST_ELO_ROLE_ID as Snowflake | undefined,
+      lowestEloRoleId: process.env.LOWEST_ELO_ROLE_ID as Snowflake | undefined
     },
     database: {
       path: getOptionalEnv('DATABASE_PATH', './data/wordle_ranked.db')

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -87,12 +87,11 @@ export function registerMessageHandler(
       updatePlayerActivity(gameDate, config.inactivityThreshold)
 
       // Update roles
-      if (message.guild) {
-        await updateRoles(
-          message.guild,
-          config.discord.highestEloRoleId,
-          config.discord.lowestEloRoleId
-        )
+      const highestEloRoleId = config.discord.highestEloRoleId
+      const lowestEloRoleId = config.discord.lowestEloRoleId
+
+      if (message.guild && highestEloRoleId && lowestEloRoleId) {
+        await updateRoles(message.guild, highestEloRoleId, lowestEloRoleId)
       }
 
       // Get updated standings

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -175,8 +175,8 @@ export interface BotConfig {
     clientId: Snowflake
     guildId?: Snowflake
     wordleBotId: Snowflake
-    highestEloRoleId: Snowflake
-    lowestEloRoleId: Snowflake
+    highestEloRoleId?: Snowflake
+    lowestEloRoleId?: Snowflake
   }
   database: {
     path: string


### PR DESCRIPTION
Make ELO role assignment optional so servers don’t have to set up special roles. If the role IDs aren’t provided, the bot skips role updates without errors. .env.example, BotConfig, and the README have been updated to reflect this.

**Changes:**
- `HIGHEST_ELO_ROLE_ID` and `LOWEST_ELO_ROLE_ID` are now optional.
- Role updates only run if both IDs are set.
- Documentation clarifies that creating ELO roles is optional.